### PR TITLE
Node Initialize

### DIFF
--- a/node.rb
+++ b/node.rb
@@ -11,6 +11,13 @@ module Raft
 # State Machine Safety:
 #   if a server has applied a log entry at a given index to its state machine, no other server will ever apply a different log entry for the same index.
   class Node
+    # think of a node as a database that stores a single value
+    # clients can send values to this server
+    # a node can be in one of three states: leader, follower, or candidate
+    # all nodes initialize in a follower state
+    # if followers don't hear from a leader they can become a candidate
+    # a candidate requests votes from other nodes, and they reply with their vote
+    # a candidate becomes a leader if it gets the majority of node votes, called Leader Election
     attr_reader :type, :heartbeat_timeout
 
     def initialize()

--- a/node.rb
+++ b/node.rb
@@ -18,19 +18,38 @@ module Raft
     # if followers don't hear from a leader they can become a candidate
     # a candidate requests votes from other nodes, and they reply with their vote
     # a candidate becomes a leader if it gets the majority of node votes, called Leader Election
-    attr_reader :type, :heartbeat_start, :heartbeat_timeout
+    attr_reader :commit_index, :last_applied, :type, :heartbeat_start, :heartbeat_timeout
 
     def initialize
       @rules = { :follower => :FOLLOWER, :candidate => :CANDIDATE, :leader => :LEADER }
 
+      @commit_index = 0
+      @last_applied = 0
       @type = @rules[:follower]
       @heartbeat_start = Time.now
-      @heartbeat_timeout = rand(150..300) * 0.001 # ms -> seconds
+      @heartbeat_timeout = rand_timeout
+    end
+
+    def run
+      while not timed_out?
+        #
+        puts self.type
+      end
     end
 
     def timed_out?
       elapsed = Time.now - @heartbeat_start
       elapsed > @heartbeat_timeout
+    end
+
+    def rand_timeout
+      rand(150..300) * 0.001 # ms -> seconds
+    end
+
+    private
+
+    def reset_heartbeat
+      @heartbeat_timeout = rand_timeout
     end
   end
 end

--- a/node.rb
+++ b/node.rb
@@ -11,12 +11,13 @@ module Raft
 # State Machine Safety:
 #   if a server has applied a log entry at a given index to its state machine, no other server will ever apply a different log entry for the same index.
   class Node
-    attr_reader :type
+    attr_reader :type, :heartbeat_timeout
 
     def initialize()
       rules = { :follower => :FOLLOWER, :candidate => :CANDIDATE, :leader => :LEADER }
 
       @type = rules[:follower]
+      @heartbeat_timeout = rand(150..300)
     end
   end
 end

--- a/node.rb
+++ b/node.rb
@@ -1,15 +1,22 @@
 module Raft
+# Raft provides the following guarantees
+# Election Safety:
+#   at most one leader can be elected in a given term.
+# Leader Append-Only:
+#   a leader never overwrites or deletes entries in its log; it only appends new entries.
+# Log Matching:
+#   if two logs contain an entry with the same index and term, then the logs are identical in all entries up through the given index.
+# Leader Completeness:
+#   if a log entry is committed in a given term, then that entry will be present in the logs of the leaders for all higher-numbered terms.
+# State Machine Safety:
+#   if a server has applied a log entry at a given index to its state machine, no other server will ever apply a different log entry for the same index.
   class Node
-    # Raft provides the following guarantees
-    # Election Safety:
-    #   at most one leader can be elected in a given term.
-    # Leader Append-Only:
-    #   a leader never overwrites or deletes entries in its log; it only appends new entries.
-    # Log Matching:
-    #   if two logs contain an entry with the same index and term, then the logs are identical in all entries up through the given index.
-    # Leader Completeness:
-    #   if a log entry is committed in a given term, then that entry will be present in the logs of the leaders for all higher-numbered terms.
-    # State Machine Safety:
-    #   if a server has applied a log entry at a given index to its state machine, no other server will ever apply a different log entry for the same index.
+    attr_reader :type
+
+    def initialize()
+      rules = { :follower => :FOLLOWER, :candidate => :CANDIDATE, :leader => :LEADER }
+
+      @type = rules[:follower]
+    end
   end
 end

--- a/node.rb
+++ b/node.rb
@@ -20,7 +20,7 @@ module Raft
     # a candidate becomes a leader if it gets the majority of node votes, called Leader Election
     attr_reader :type, :heartbeat_timeout
 
-    def initialize()
+    def initialize
       rules = { :follower => :FOLLOWER, :candidate => :CANDIDATE, :leader => :LEADER }
 
       @type = rules[:follower]

--- a/node.rb
+++ b/node.rb
@@ -18,13 +18,19 @@ module Raft
     # if followers don't hear from a leader they can become a candidate
     # a candidate requests votes from other nodes, and they reply with their vote
     # a candidate becomes a leader if it gets the majority of node votes, called Leader Election
-    attr_reader :type, :heartbeat_timeout
+    attr_reader :type, :heartbeat_start, :heartbeat_timeout
 
     def initialize
-      rules = { :follower => :FOLLOWER, :candidate => :CANDIDATE, :leader => :LEADER }
+      @rules = { :follower => :FOLLOWER, :candidate => :CANDIDATE, :leader => :LEADER }
 
-      @type = rules[:follower]
-      @heartbeat_timeout = rand(150..300)
+      @type = @rules[:follower]
+      @heartbeat_start = Time.now
+      @heartbeat_timeout = rand(150..300) * 0.001 # ms -> seconds
+    end
+
+    def timed_out?
+      elapsed = Time.now - @heartbeat_start
+      elapsed > @heartbeat_timeout
     end
   end
 end

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -15,7 +15,12 @@ describe Raft::Node do
     end
 
     it 'should initialize with a heatbeat timer' do
-      expect(node.heartbeat_start).to be < Time.now
+      expect(node.heartbeat_start.class).to be Time
+    end
+
+    it 'should initialize with a commitIndex and lastApplied indeces to 0' do
+      expect(node.commit_index).to be 0
+      expect(node.last_applied).to be 0
     end
   end
 end

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -5,7 +5,7 @@ describe Raft::Node do
     let(:node) { Raft::Node.new }
 
     it 'should be in a follower state' do
-      expect(node.type).to eq 'FOLLOWER'
+      expect(node.type).to eq :FOLLOWER
     end
   end
 end

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -7,5 +7,11 @@ describe Raft::Node do
     it 'should be in a follower state' do
       expect(node.type).to eq :FOLLOWER
     end
+
+    it ' initialize with a heartbeat timeout between 150ms and 300ms' do
+      expect(node.heartbeat_timeout.class).to be Integer
+      expect(node.heartbeat_timeout).to be >= 150
+      expect(node.heartbeat_timeout).to be <= 300
+    end
   end
 end

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -1,7 +1,11 @@
 require "spec_helper"
 
 describe Raft::Node do
-  it 'exists' do
-    expect(Raft::Node.new.class).to be(Raft::Node)
+  context 'when the node is initialized' do
+    let(:node) { Raft::Node.new }
+
+    it 'should be in a follower state' do
+      expect(node.type).to eq 'FOLLOWER'
+    end
   end
 end

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -8,7 +8,7 @@ describe Raft::Node do
       expect(node.type).to eq :FOLLOWER
     end
 
-    it ' initialize with a heartbeat timeout between 150ms and 300ms' do
+    it 'should initialize with a heartbeat timeout between 150ms and 300ms' do
       expect(node.heartbeat_timeout.class).to be Integer
       expect(node.heartbeat_timeout).to be >= 150
       expect(node.heartbeat_timeout).to be <= 300

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -9,9 +9,13 @@ describe Raft::Node do
     end
 
     it 'should initialize with a heartbeat timeout between 150ms and 300ms' do
-      expect(node.heartbeat_timeout.class).to be Integer
-      expect(node.heartbeat_timeout).to be >= 150
-      expect(node.heartbeat_timeout).to be <= 300
+      expect(node.heartbeat_timeout.class).to be Float
+      expect(node.heartbeat_timeout).to be >= 0.15
+      expect(node.heartbeat_timeout).to be <= 0.3
+    end
+
+    it 'should initialize with a heatbeat timer' do
+      expect(node.heartbeat_start).to be < Time.now
     end
   end
 end


### PR DESCRIPTION
This introduces an implementation + two tests for when the `Raft::Node` class is initialized:

* a node should initialize with a follower state
* it should initialize with a heartbeat timeout between 150ms and 300ms

documentation specific to `Raft::Node` is added along with `Raft`'s guarantees to the `Raft` module